### PR TITLE
Fix `getblockstats` to use the exact block specified by height or hash

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -866,7 +866,7 @@ UniValue getblockstats(const JSONRPCRequest& request) {
           throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Target block height %d after current tip %d", height, current_tip));
       }
 
-      pindex = pindexBestHeader;
+      pindex = chainActive[height];
     } else {
       const uint256 hash(ParseHashV(request.params[0], "hash_or_height"));
       pindex = mapBlockIndex[hash];


### PR DESCRIPTION
- Modified logic to ensure `getblockstats` retrieves the precise block based on the given height or hash, preventing fallback to the latest block.
- Updated `pindex` assignment to directly access the block from `chainActive` when a block height is provided.
- Ensured block retrieval consistency for both hash and height inputs.